### PR TITLE
Migrate pipeline to DSL2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Nextflow pipeline for reproducible metabolomics data processing with MS-DIAL**.
 
-[![Nextflow](https://img.shields.io/badge/nextflow-%E2%89%A520.04.0-brightgreen.svg)](https://www.nextflow.io/)
+[![Nextflow](https://img.shields.io/badge/nextflow-%E2%89%A522.10.0-brightgreen.svg)](https://www.nextflow.io/)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/104f754fa0854cc49e7f84ce73b7c440)](https://app.codacy.com/gh/Nextflow4Metabolomics/nextflow4ms-dial/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 ## Introduction
@@ -31,7 +31,7 @@ The workflow support MacOS and Linux operating systems. Notably, the workflow ha
 
 2. Run the pipeline with example data:
     ```bash
-    nextflow main.nf -profile functional_test > logs/execution.log
+    nextflow run main.nf -profile functional_test > logs/execution.log
     ```
 
 ## Example data and Results
@@ -39,7 +39,7 @@ The workflow support MacOS and Linux operating systems. Notably, the workflow ha
 - Example data: https://drive.google.com/drive/folders/1atsy-TlfJSs0sw2ZCvbkqOSAbZFYRqdy, which is the publicly available data from the publication “Li, Z., Lu, Y., Guo, Y., Cao, H., Wang, Q., & Shui, W. (2018). Comprehensive evaluation of untargeted metabolomics data processing software in feature detection, quantification, and discriminating marker selection. Analytica Chimica Acta, 1029, 50–57”. The data has ten samples in total and five samples in each of the two groups. The protocol regarding processing this data is also publicly available at MetaboLights MTBLS733 (https://www.ebi.ac.uk/metabolights/editor/MTBLS733/protocols).
 - Execution command: 
     ```bash
-    nextflow main.nf -profile docker > logs/execution.log
+    nextflow run main.nf -profile docker > logs/execution.log
     ```
 - Example results are stored in the "results" folder. Note that the file extensions of all produced ".msdial" files have been changed to ".tsv" which enables the files to be opened with Excel software.
 - The execution logs for the example data are stored at "logs" folder.
@@ -55,7 +55,7 @@ The workflow support MacOS and Linux operating systems. Notably, the workflow ha
 4. Put MS1 library and MS2 library to the `data/` folder, and name them `ms1_lib.txt` and `ms2_lib.msp`. Example files can be found in `functional_test/sample_data/`.
 3. Run the pipeline (use "docker" as the profile when running locally, and "singularity" as the profile when running with a high-performance computing system):
     ```bash
-    nextflow main.nf -profile docker > logs/execution.log
+    nextflow run main.nf -profile docker > logs/execution.log
     ```
 
 ## Configuration

--- a/conf/HiPerGator.config
+++ b/conf/HiPerGator.config
@@ -46,19 +46,19 @@ process
     withName: peak_detection_msdial
     {
         time =  { check_max( 6.h * task.attempt, 'time' ) }
-        max_cpus = { check_max( 3 * task.attempt, 'cpus' ) }
+        cpus = { check_max( 3 * task.attempt, 'cpus' ) }
         memory = { check_max( 50.GB * task.attempt, 'memory' ) }
     }
     withName: msflo_download
     {
         time =  '15m'
-        max_cpus = 1
+        cpus = 1
         memory = '4 GB'  
     }
     withName: msflo_processing
     {
         time =  { check_max( 6.h * task.attempt, 'time' ) }
-        max_cpus = { check_max( 3 * task.attempt, 'cpus' ) }
+        cpus = { check_max( 3 * task.attempt, 'cpus' ) }
         memory = { check_max( 50.GB * task.attempt, 'memory' ) }
     }
 }

--- a/conf/base.config
+++ b/conf/base.config
@@ -46,19 +46,19 @@ process
     withName: peak_detection_msdial
     {
         time =  '1800m'
-        max_cpus = 2
-        max_memory = '9 GB'  
+        cpus = 2
+        memory = '9 GB'  
     }
     withName: msflo_download
     {
         time =  '15m'
-        max_cpus = 1
-        max_memory = '4 GB'  
+        cpus = 1
+        memory = '4 GB'  
     }
     withName: msflo_processing
     {
         time =  '1800m'
-        max_cpus = 2
-        max_memory = '9 GB'  
+        cpus = 2
+        memory = '9 GB'  
     }
 }

--- a/main.nf
+++ b/main.nf
@@ -1,5 +1,7 @@
 #!/usr/bin/env nextflow
 
+nextflow.enable.dsl=2
+
 /**
     A Nextflow-based reproducible pipeline for untargeted metabolomics data analysis
     Description  : RUMP: A Nextflow-based reproducible pipeline for untargeted metabolomics data processing
@@ -25,23 +27,8 @@
     - https://github.com/Nextflow4Metabolomics/nextflow4ms-dial
 */
 
-// Those variable names which are all uppercase are channel names
-
 version='1.0dev'
 timestamp='20221009'
-
-DATA_DIR = Channel.fromPath(params.input_dir, type: 'dir') // Location of folder storing positive data
-
-// Config files
-MSDIAL_CONFIG = Channel.fromPath(params.msdial_config)
-MSFLO_CONFIG = Channel.fromPath(params.msflo_config)
-
-// Library
-MS1_LIBRARY = Channel.fromPath(params.ms1_library)
-MS2_LIBRARY = Channel.fromPath(params.ms2_library)
-
-// Reference files
-REF = Channel.fromPath(params.ref)
 
 /**
     Basic running information
@@ -68,7 +55,7 @@ if (params.help) {
     System.out.println("https://github.com/Nextflow4Metabolomics/nextflow4ms-dial/wiki")
     System.out.println("")
     System.out.println("Usage:  ")
-    System.out.println("   nextflow main.nf -profile [options: functional_test; docker; singularity]")
+    System.out.println("   nextflow run main.nf -profile [options: functional_test; docker; singularity]")
     System.out.println("")
     System.out.println("Arguments (it is mandatory to change `input_file` and `mzmine_dir` before running:")
     System.out.println("----------------------------- common parameters ----------------------------------")
@@ -124,21 +111,21 @@ log.info "-\033[2m--------------------------------------------------\033[0m-"
 */
 process peak_detection_msdial {
 
-    echo true
+    debug true
 
     publishDir './results/'
 
     input:
-    file msdial_config from MSDIAL_CONFIG // Config file for MS-DIAL to process negative data.
-    file data from DATA_DIR // Location of data files
-    file ms1_lib from MS1_LIBRARY // Location of MS1 library file for negative samples
-    file ms2_lib from MS2_LIBRARY // Location of MS2 library file for negative samples
-    file ref from REF
+    path msdial_config // Config file for MS-DIAL to process negative data.
+    path data // Location of data files
+    path ms1_lib // Location of MS1 library file for negative samples
+    path ms2_lib // Location of MS2 library file for negative samples
+    path ref
 
 
     output:
-    file "ms-dial/AlignResult*.msdial" into MSDIAL_RESULT // MS-DIAL processing result for the data.
-    stdout msdial_result
+    path "ms-dial/AlignResult*.msdial", emit: msdial_result // MS-DIAL processing result for the data.
+    stdout emit: msdial_result_log
 
     shell:
     """
@@ -157,7 +144,7 @@ process msflo_download{
     publishDir './'
 
     output:
-    file "ms-flo" into MSFLO_SOFTWARE
+    path "ms-flo", emit: msflo_software
 
     shell:
     """
@@ -173,18 +160,18 @@ process msflo_download{
 */
 process msflo_processing{
     
-    echo true
+    debug true
 
     publishDir './results/'
     
     input:
-    file msflo from MSFLO_SOFTWARE // Load MS-FLO software from the channel.
-    file msflo_config from MSFLO_CONFIG // Config file for MS-FLO to process negative data.
-    file msdial_result from MSDIAL_RESULT // Fetch aligned result from MS-DIAL
+    path msflo // Load MS-FLO software from the channel.
+    path msflo_config // Config file for MS-FLO to process negative data.
+    path msdial_result // Fetch aligned result from MS-DIAL
 
     output:
-    file "ms-flo/AlignResult*_processed.msdial" into MSFLO_RESULT
-    stdout msflo_result
+    path "ms-flo/AlignResult*_processed.msdial", emit: msflo_result
+    stdout emit: msflo_result_log
 
     shell:
     """
@@ -193,4 +180,22 @@ process msflo_processing{
     python3 run_msflo.py -f msdial ${msflo_config} ${msdial_result}
     """
 
+}
+
+workflow {
+    peak_detection_msdial(
+        Channel.fromPath(params.msdial_config),
+        Channel.fromPath(params.input_dir, type: 'dir'),
+        Channel.fromPath(params.ms1_library),
+        Channel.fromPath(params.ms2_library),
+        Channel.fromPath(params.ref)
+    )
+
+    msflo_download()
+
+    msflo_processing(
+        msflo_download.out.msflo_software,
+        Channel.fromPath(params.msflo_config),
+        peak_detection_msdial.out.msdial_result
+    )
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,7 +28,7 @@ manifest {
   homePage = 'https://github.com/Nextflow4Metabolomics/nextflow4ms-dial'
   description = 'A Nextflow-based reproducible pipeline for untargeted metabolomics data analysis'
   mainScript = 'main.nf'
-  nextflowVersion = '>=20.04.0'
+  nextflowVersion = '>=22.10.0'
   version = '1.0dev'
 }
 


### PR DESCRIPTION
Summary
- migrate main.nf from DSL1 channel wiring to minimal DSL2 workflow wiring
- update legacy process and resource directives needed for current Nextflow compatibility
- refresh README run examples to use nextflow run

Validation
- ran nextflow run main.nf -profile functional_test
- completed successfully on Nextflow 25.10.4
- observed only a non-fatal Graphviz warning for DAG rendering