### PR TITLE
Fix GitHub Actions Nextflow config parsing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
     - main
+  pull_request:
+    branches:
+    - main
   schedule:
     - cron: "0 2 * * 1-5"
 jobs:

--- a/nextflow.config
+++ b/nextflow.config
@@ -122,10 +122,9 @@ profiles {
   }
 }
 
-// Function to ensure that resource requirements don't go beyond
-// a maximum limit
-def check_max(obj, type) {
-  if (type == 'memory') {
+// Closure to ensure resource requirements don't go beyond a maximum limit.
+check_max = { obj, resourceType ->
+  if (resourceType == 'memory') {
     try {
       if (obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
         return params.max_memory as nextflow.util.MemoryUnit
@@ -135,7 +134,7 @@ def check_max(obj, type) {
       println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
       return obj
     }
-  } else if (type == 'time') {
+  } else if (resourceType == 'time') {
     try {
       if (obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
         return params.max_time as nextflow.util.Duration
@@ -145,7 +144,7 @@ def check_max(obj, type) {
       println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
       return obj
     }
-  } else if (type == 'cpus') {
+  } else if (resourceType == 'cpus') {
     try {
       return Math.min( obj, params.max_cpus as int )
     } catch (all) {


### PR DESCRIPTION
## Summary
- Replace the top-level nextflow.config helper method with a strict-syntax-compatible closure
- Add a pull_request trigger so CI can run before future merges to main

## Context
GitHub Actions failed with Nextflow 26.04.3 because strict config syntax no longer accepts top-level function declarations such as def check_max(obj, type).