### PR TITLE
Fix CI: restore closure syntax for check_max and re-add pull_request trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
     - main
+  pull_request:
+    branches:
+    - main
   schedule:
     - cron: "0 2 * * 1-5"
 jobs:

--- a/main.nf
+++ b/main.nf
@@ -27,10 +27,7 @@ nextflow.enable.dsl=2
     - https://github.com/Nextflow4Metabolomics/nextflow4ms-dial
 */
 
-def version = '1.0dev'
-def timestamp = '20221009'
-
-/** 
+/**
     Process description: Process for running MS-DIAL with negative mode batchfile and data to generate peak table of negative mode.
     Inputs: MS-DIAL config file; raw .mzML data; MS1 library; MS2 library; reference file.
     Outputs: The peak table produced by MS-DIAL after processing all raw data.
@@ -109,6 +106,9 @@ process msflo_processing{
 }
 
 workflow {
+    def version = '1.0dev'
+    def timestamp = '20221009'
+
     // Basic running information
     println "Project : $workflow.projectDir"
     println "Git info: $workflow.repository - $workflow.revision [$workflow.commitId]"

--- a/main.nf
+++ b/main.nf
@@ -27,82 +27,8 @@ nextflow.enable.dsl=2
     - https://github.com/Nextflow4Metabolomics/nextflow4ms-dial
 */
 
-version='1.0dev'
-timestamp='20221009'
-
-/**
-    Basic running information
-*/
-
-println "Project : $workflow.projectDir"
-println "Git info: $workflow.repository - $workflow.revision [$workflow.commitId]"
-println "Cmd line: $workflow.commandLine"
-println "Manifest's pipeline version: $workflow.manifest.version"
-
-/**
-    Prints help when asked for
-*/
-
-if (params.help) {
-    System.out.println("")
-    System.out.println("A Nextflow-based reproducible pipeline for untargeted metabolomics data analysis - Version: $version ($timestamp)")
-    System.out.println("This pipeline is distributed in the hope that it will be useful")
-    System.out.println("but WITHOUT ANY WARRANTY. See the MIT License for more details.")
-    System.out.println("")
-    System.out.println("Please report comments and bugs to the issue tracking on GitHub")
-    System.out.println("at https://github.com/Nextflow4Metabolomics/nextflow4ms-dial/issues.")
-    System.out.println("Check https://github.com/Nextflow4Metabolomics/nextflow4ms-dial for updates, and refer to")
-    System.out.println("https://github.com/Nextflow4Metabolomics/nextflow4ms-dial/wiki")
-    System.out.println("")
-    System.out.println("Usage:  ")
-    System.out.println("   nextflow run main.nf -profile [options: functional_test; docker; singularity]")
-    System.out.println("")
-    System.out.println("Arguments (it is mandatory to change `input_file` and `mzmine_dir` before running:")
-    System.out.println("----------------------------- common parameters ----------------------------------")
-    System.out.println("    -profile                                docker (run pipeline locally), singularity (run pipeline on supercomputer), or test (run test data locally with docker)")
-    System.out.println("    --help                                  whether to show help information or not, default is null")
-    System.out.println("Please refer to nextflow.config for more options.")
-    System.out.println("")
-    System.out.println("The workflow supports .mzML format files.")
-    System.out.println("The workflow supports MacOS and Linux operating systems.")
-    System.out.println("")
-    exit 1
-}
-
-custom_runName = params.name
-if (!(workflow.runName ==~ /[a-z]+_[a-z]+/)) {
-    custom_runName = workflow.runName
-}
-
-// Header log info
-def summary = [:]
-summary['Pipeline Name']  = 'RUMP'
-if(workflow.revision) summary['Pipeline Release'] = workflow.revision
-summary['Run Name']         = custom_runName ?: workflow.runName
-summary['Input']            = params.input
-summary['Max Resources']    = "$params.max_memory memory, $params.max_cpus cpus, $params.max_time time per job"
-if (workflow.containerEngine) summary['Container'] = "$workflow.containerEngine - $workflow.container"
-summary['Output dir']       = params.outdir
-summary['Launch dir']       = workflow.launchDir
-summary['Working dir']      = workflow.workDir
-summary['Script dir']       = workflow.projectDir
-summary['User']             = workflow.userName
-if (workflow.profile.contains('awsbatch')) {
-    summary['AWS Region']   = params.awsregion
-    summary['AWS Queue']    = params.awsqueue
-    summary['AWS CLI']      = params.awscli
-}
-summary['Config Profile'] = workflow.profile
-if (params.config_profile_description) summary['Config Profile Description'] = params.config_profile_description
-if (params.config_profile_contact)     summary['Config Profile Contact']     = params.config_profile_contact
-if (params.config_profile_url)         summary['Config Profile URL']         = params.config_profile_url
-summary['Config Files'] = workflow.configFiles.join(', ')
-if (params.email || params.email_on_fail) {
-    summary['E-mail Address']    = params.email
-    summary['E-mail on failure'] = params.email_on_fail
-}
-log.info summary.collect { k,v -> "${k.padRight(18)}: $v" }.join("\n")
-log.info "-\033[2m--------------------------------------------------\033[0m-"
+def version = '1.0dev'
+def timestamp = '20221009'
 
 /** 
     Process description: Process for running MS-DIAL with negative mode batchfile and data to generate peak table of negative mode.
@@ -183,6 +109,74 @@ process msflo_processing{
 }
 
 workflow {
+    // Basic running information
+    println "Project : $workflow.projectDir"
+    println "Git info: $workflow.repository - $workflow.revision [$workflow.commitId]"
+    println "Cmd line: $workflow.commandLine"
+    println "Manifest's pipeline version: $workflow.manifest.version"
+
+    // Prints help when asked for
+    if (params.help) {
+        System.out.println("")
+        System.out.println("A Nextflow-based reproducible pipeline for untargeted metabolomics data analysis - Version: $version ($timestamp)")
+        System.out.println("This pipeline is distributed in the hope that it will be useful")
+        System.out.println("but WITHOUT ANY WARRANTY. See the MIT License for more details.")
+        System.out.println("")
+        System.out.println("Please report comments and bugs to the issue tracking on GitHub")
+        System.out.println("at https://github.com/Nextflow4Metabolomics/nextflow4ms-dial/issues.")
+        System.out.println("Check https://github.com/Nextflow4Metabolomics/nextflow4ms-dial for updates, and refer to")
+        System.out.println("https://github.com/Nextflow4Metabolomics/nextflow4ms-dial/wiki")
+        System.out.println("")
+        System.out.println("Usage:  ")
+        System.out.println("   nextflow run main.nf -profile [options: functional_test; docker; singularity]")
+        System.out.println("")
+        System.out.println("Arguments (it is mandatory to change `input_file` and `mzmine_dir` before running:")
+        System.out.println("----------------------------- common parameters ----------------------------------")
+        System.out.println("    -profile                                docker (run pipeline locally), singularity (run pipeline on supercomputer), or test (run test data locally with docker)")
+        System.out.println("    --help                                  whether to show help information or not, default is null")
+        System.out.println("Please refer to nextflow.config for more options.")
+        System.out.println("")
+        System.out.println("The workflow supports .mzML format files.")
+        System.out.println("The workflow supports MacOS and Linux operating systems.")
+        System.out.println("")
+        exit 1
+    }
+
+    def custom_runName = params.name
+    if (!(workflow.runName ==~ /[a-z]+_[a-z]+/)) {
+        custom_runName = workflow.runName
+    }
+
+    // Header log info
+    def summary = [:]
+    summary['Pipeline Name']  = 'RUMP'
+    if (workflow.revision) summary['Pipeline Release'] = workflow.revision
+    summary['Run Name']         = custom_runName ?: workflow.runName
+    summary['Input']            = params.input
+    summary['Max Resources']    = "$params.max_memory memory, $params.max_cpus cpus, $params.max_time time per job"
+    if (workflow.containerEngine) summary['Container'] = "$workflow.containerEngine - $workflow.container"
+    summary['Output dir']       = params.outdir
+    summary['Launch dir']       = workflow.launchDir
+    summary['Working dir']      = workflow.workDir
+    summary['Script dir']       = workflow.projectDir
+    summary['User']             = workflow.userName
+    if (workflow.profile.contains('awsbatch')) {
+        summary['AWS Region']   = params.awsregion
+        summary['AWS Queue']    = params.awsqueue
+        summary['AWS CLI']      = params.awscli
+    }
+    summary['Config Profile'] = workflow.profile
+    if (params.config_profile_description) summary['Config Profile Description'] = params.config_profile_description
+    if (params.config_profile_contact)     summary['Config Profile Contact']     = params.config_profile_contact
+    if (params.config_profile_url)         summary['Config Profile URL']         = params.config_profile_url
+    summary['Config Files'] = workflow.configFiles.join(', ')
+    if (params.email || params.email_on_fail) {
+        summary['E-mail Address']    = params.email
+        summary['E-mail on failure'] = params.email_on_fail
+    }
+    log.info summary.collect { k,v -> "${k.padRight(18)}: $v" }.join("\n")
+    log.info "-\033[2m--------------------------------------------------\033[0m-"
+
     peak_detection_msdial(
         Channel.fromPath(params.msdial_config),
         Channel.fromPath(params.input_dir, type: 'dir'),

--- a/nextflow.config
+++ b/nextflow.config
@@ -122,10 +122,9 @@ profiles {
   }
 }
 
-// Function to ensure that resource requirements don't go beyond
-// a maximum limit
-def check_max(obj, type) {
-  if (type == 'memory') {
+// Closure to ensure resource requirements don't go beyond a maximum limit.
+check_max = { obj, resourceType ->
+  if (resourceType == 'memory') {
     try {
       if (obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
         return params.max_memory as nextflow.util.MemoryUnit
@@ -135,7 +134,7 @@ def check_max(obj, type) {
       println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
       return obj
     }
-  } else if (type == 'time') {
+  } else if (resourceType == 'time') {
     try {
       if (obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
         return params.max_time as nextflow.util.Duration
@@ -145,7 +144,7 @@ def check_max(obj, type) {
       println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
       return obj
     }
-  } else if (type == 'cpus') {
+  } else if (resourceType == 'cpus') {
     try {
       return Math.min( obj, params.max_cpus as int )
     } catch (all) {


### PR DESCRIPTION
## What changed
- `nextflow.config`: Restored `check_max` as a closure (`check_max = { obj, resourceType -> }`) instead of a `def` function. Nextflow requires closure syntax for top-level config assignments.
- `.github/workflows/main.yml`: Re-added the `pull_request` trigger so CI runs on PRs, and restored the trailing newline.

## Why
The revert of PR #10 (commit 910ba83) accidentally restored the broken `def check_max(obj, type)` syntax that had been fixed in f4a94df ("Fix Nextflow config parsing in CI"). This caused the CI check on the PR #11 merge commit (2aabdfe) to fail (0/1).

## Reviewer notes
This change is identical to what f4a94df established â€” no logic changes, only syntax and workflow trigger restoration.
